### PR TITLE
src: filtering undefined keys from environment

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -146,9 +146,12 @@ export default {
     },
 
     _getAdditionalCapabilities () {
-        const capabilitiesFromEnvironment = filter(this._getCapabilitiesFromEnvironment(), value => value !== void 0);
-
-        return { ...this._getCapabilitiesFromConfig(), ...capabilitiesFromEnvironment };
+        const environmentCapabilities = this._getCapabilitiesFromEnvironment();
+        const filterUndefinedKeys = Object
+                                        .keys(environmentCapabilities)
+                                        .filter(k => environmentCapabilities[k] !== undefined)
+                                        .reduce((res, key) => (res[key] = environmentCapabilities[key], res), {});
+        return { ...this._getCapabilitiesFromConfig(), ...filterUndefinedKeys };
     },
 
     _filterPlatformInfo (query) {


### PR DESCRIPTION
When passed some environment variables, wrong capabilities are being
sent for initialization. This can be avoided as the native api is
sufficient for such task and is more performant.